### PR TITLE
fix: update branch references from master to main in workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,9 @@ name: Go
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
 


### PR DESCRIPTION
This pull request updates the branch references in the GitHub Actions workflow configuration file `.github/workflows/go.yml`. The changes ensure compatibility with the repository's updated default branch name.

Branch updates:

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL5-R7): Changed branch references from `master` to `main` for both `push` and `pull_request` events to align with the repository's default branch naming convention.


Part of: https://github.com/flatcar/Flatcar/issues/1714